### PR TITLE
Shimmer ViewHolder Layout misconfiguration

### DIFF
--- a/shimmer/src/main/res/layout/viewholder_shimmer.xml
+++ b/shimmer/src/main/res/layout/viewholder_shimmer.xml
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 -->
-<io.supercharge.shimmerlayout.ShimmerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+<io.supercharge.shimmerlayout.ShimmerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content" />


### PR DESCRIPTION
Shimmer has a little attribute misconfiguration which is that the width is set to wrap_content and this means that the child layout will need to be given a specific width size so display else if set to match_parent or wrap_content will simply be ignore/overwritten by the wrap_content of it parent and so, layout that are expected to take the whole width will not if they don't have a specific size assigned to them, this is what I notice and after few hours of debugging, I spot it and made the corrections and test to be sure all is fine and nothing is broken. note that gridlayout is not affected either since that is taken care of by the layoutmanager and I tested that also and i'm sure everything is working fine.